### PR TITLE
Don't parse media queries at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ yarn add react-native-css-media-query-processor --dev
 
 ## Usage
 
+This library takes parsed CSS with media queries and matches it during runtime with React Native's current device dimensions and device orientation.
+
+To minimize runtime performance hit, the media queries must be parsed already before calling `process` function. Have a look at the example to see how the parsed syntax looks like.
+
 You can use this library together with [css-to-react-native-transform](https://github.com/kristerkari/css-to-react-native-transform) to transform a string of CSS containing media queries to an React Native style object.
 
 Notice that there is no syntax validation for CSS media queries. This is done to ensure that the media query matching is as fast as possible. If you want to validate syntax for the media queries, you should do that when they are parsed to style objects (that's what [css-to-react-native-transform](https://github.com/kristerkari/css-to-react-native-transform) does).
+
+### Example
 
 Given that React Native returns the following dimensions:
 
@@ -34,6 +40,8 @@ import { Dimensions } from "react-native";
 Dimensions.get("window");
 // => { width: 110, height: 100 }
 ```
+
+This is a simplified example of how the CSS gets transformed in to a React Native compatible style object:
 
 `App.css`:
 
@@ -61,9 +69,47 @@ Dimensions.get("window");
 ```js
 import styles from "./App.css";
 import transform from "css-to-react-native-transform";
-import { process } from "react-native-css-media-query-processor";
+transform(styles, { parseMediaQueries: true });
+```
 
-process(transform(styles, { parseMediaQueries: true }));
+↓ ↓ ↓ ↓ ↓ ↓
+
+```js
+{
+  __mediaQueries: {
+    "@media (min-width: 50px) and (max-width: 150px)": [
+      {
+        inverse: false,
+        type: "all",
+        expressions: [
+          { modifier: "min", feature: "width", value: "50px" },
+          { modifier: "max", feature: "width", value: "150px" }
+        ]
+      }
+    ]
+  },
+  foo: {
+    color: "red"
+  },
+  bar: {
+    fontSize: 16
+  },
+  "@media (min-width: 50px) and (max-width: 150px)": {
+    foo: {
+      color: "blue"
+    },
+    bar: {
+      fontSize: 32
+    }
+  }
+}
+```
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+```js
+import { process } from "react-native-css-media-query-processor";
+process(styleObject);
 ```
 
 ↓ ↓ ↓ ↓ ↓ ↓

--- a/benchmark.js
+++ b/benchmark.js
@@ -9,21 +9,27 @@ var parsed = require("./dist/perf-tests/parsed").process;
 
 var styles = {
   __mediaQueries: {
-    "@media screen and (max-width: 55rem)": {
-      inverse: false,
-      type: "@media",
-      expressions: [{ modifier: "max", feature: "width", value: "55rem" }]
-    },
-    "@media screen and (max-width: 52.375rem)": {
-      inverse: false,
-      type: "@media",
-      expressions: [{ modifier: "max", feature: "width", value: "52.375rem" }]
-    },
-    "@media screen and (max-width: 32rem)": {
-      inverse: false,
-      type: "@media",
-      expressions: [{ modifier: "max", feature: "width", value: "32rem" }]
-    }
+    "@media screen and (max-width: 55rem)": [
+      {
+        inverse: false,
+        type: "@media",
+        expressions: [{ modifier: "max", feature: "width", value: "55rem" }]
+      }
+    ],
+    "@media screen and (max-width: 52.375rem)": [
+      {
+        inverse: false,
+        type: "@media",
+        expressions: [{ modifier: "max", feature: "width", value: "52.375rem" }]
+      }
+    ],
+    "@media screen and (max-width: 32rem)": [
+      {
+        inverse: false,
+        type: "@media",
+        expressions: [{ modifier: "max", feature: "width", value: "32rem" }]
+      }
+    ]
   },
   header: {
     width: "90%",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "src",
     "!**/__tests__",
     "!**/__mocks__",
+    "!**/perf-tests",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -17,6 +17,25 @@ describe("media queries", () => {
   const process = require("../index").process;
   it("should extract and apply media queries", () => {
     const obj = {
+      __mediaQueries: {
+        "@media (min-width: 50px) and (min-height: 100px)": [
+          {
+            inverse: false,
+            type: "all",
+            expressions: [
+              { modifier: "min", feature: "width", value: "50px" },
+              { modifier: "min", feature: "height", value: "100px" }
+            ]
+          }
+        ],
+        "@media ios": [
+          {
+            inverse: false,
+            type: "ios",
+            expressions: []
+          }
+        ]
+      },
       a: 1,
       b: 2,
       e: {
@@ -51,6 +70,28 @@ describe("media queries", () => {
 
   it("should not modify passed in object", () => {
     const styles = {
+      __mediaQueries: {
+        "@media (min-width: 50px) and (max-width: 150px)": [
+          {
+            inverse: false,
+            type: "all",
+            expressions: [
+              { modifier: "min", feature: "width", value: "50px" },
+              { modifier: "max", feature: "width", value: "150px" }
+            ]
+          }
+        ],
+        "@media (min-width: 150px) and (max-width: 200px)": [
+          {
+            inverse: false,
+            type: "all",
+            expressions: [
+              { modifier: "min", feature: "width", value: "150px" },
+              { modifier: "max", feature: "width", value: "200px" }
+            ]
+          }
+        ]
+      },
       "@media (min-width: 50px) and (max-width: 150px)": {
         a: 1
       },
@@ -63,6 +104,28 @@ describe("media queries", () => {
 
     expect(result).toEqual({ a: 1 });
     expect(styles).toEqual({
+      __mediaQueries: {
+        "@media (min-width: 50px) and (max-width: 150px)": [
+          {
+            inverse: false,
+            type: "all",
+            expressions: [
+              { modifier: "min", feature: "width", value: "50px" },
+              { modifier: "max", feature: "width", value: "150px" }
+            ]
+          }
+        ],
+        "@media (min-width: 150px) and (max-width: 200px)": [
+          {
+            inverse: false,
+            type: "all",
+            expressions: [
+              { modifier: "min", feature: "width", value: "150px" },
+              { modifier: "max", feature: "width", value: "200px" }
+            ]
+          }
+        ]
+      },
       "@media (min-width: 50px) and (max-width: 150px)": {
         a: 1
       },
@@ -75,6 +138,28 @@ describe("media queries", () => {
   it("should allow memoized objects to be passed in", () => {
     const styles = b => {
       return {
+        __mediaQueries: {
+          "@media (min-width: 50px) and (max-width: 150px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "width", value: "50px" },
+                { modifier: "max", feature: "width", value: "150px" }
+              ]
+            }
+          ],
+          "@media (min-width: 150px) and (max-width: 200px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "width", value: "150px" },
+                { modifier: "max", feature: "width", value: "200px" }
+              ]
+            }
+          ]
+        },
         a: b,
         "@media (min-width: 50px) and (max-width: 150px)": {
           a: 1
@@ -92,6 +177,28 @@ describe("media queries", () => {
   it("should process width", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media (min-width: 50px) and (max-width: 150px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "width", value: "50px" },
+                { modifier: "max", feature: "width", value: "150px" }
+              ]
+            }
+          ],
+          "@media (min-width: 150px) and (max-width: 200px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "width", value: "150px" },
+                { modifier: "max", feature: "width", value: "200px" }
+              ]
+            }
+          ]
+        },
         "@media (min-width: 50px) and (max-width: 150px)": {
           a: 1
         },
@@ -105,6 +212,28 @@ describe("media queries", () => {
   it("should process height", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media (min-height: 50px) and (max-height: 150px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "50px" },
+                { modifier: "max", feature: "height", value: "150px" }
+              ]
+            }
+          ],
+          "@media (min-height: 150px) and (max-height: 200px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "150px" },
+                { modifier: "max", feature: "height", value: "200px" }
+              ]
+            }
+          ]
+        },
         "@media (min-height: 50px) and (max-height: 150px)": {
           a: 1
         },
@@ -118,6 +247,28 @@ describe("media queries", () => {
   it("should support rem", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media (min-height: 3.125rem) and (max-height: 9.375rem)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "3.125rem" },
+                { modifier: "max", feature: "height", value: "9.375rem" }
+              ]
+            }
+          ],
+          "@media (min-height: 9.375rem) and (max-height: 12.5rem)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "9.375rem" },
+                { modifier: "max", feature: "height", value: "12.5rem" }
+              ]
+            }
+          ]
+        },
         "@media (min-height: 3.125rem) and (max-height: 9.375rem)": {
           a: 1
         },
@@ -128,6 +279,28 @@ describe("media queries", () => {
     ).toEqual({ a: 1 });
     expect(
       process({
+        __mediaQueries: {
+          "@media screen and (min-height: 9.375rem) and (max-height: 12.5rem)": [
+            {
+              inverse: false,
+              type: "screen",
+              expressions: [
+                { modifier: "min", feature: "height", value: "9.375rem" },
+                { modifier: "max", feature: "height", value: "12.5rem" }
+              ]
+            }
+          ],
+          "@media screen and (min-height: 3.125rem) and (max-height: 9.375rem)": [
+            {
+              inverse: false,
+              type: "screen",
+              expressions: [
+                { modifier: "min", feature: "height", value: "3.125rem" },
+                { modifier: "max", feature: "height", value: "9.375rem" }
+              ]
+            }
+          ]
+        },
         a: 0,
         "@media screen and (min-height: 9.375rem) and (max-height: 12.5rem)": {
           a: 1
@@ -142,6 +315,28 @@ describe("media queries", () => {
   it("should support screen type", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media screen and (min-height: 50px) and (max-height: 150px)": [
+            {
+              inverse: false,
+              type: "screen",
+              expressions: [
+                { modifier: "min", feature: "height", value: "50px" },
+                { modifier: "max", feature: "height", value: "150px" }
+              ]
+            }
+          ],
+          "@media screen and (min-height: 150px) and (max-height: 200px)": [
+            {
+              inverse: false,
+              type: "screen",
+              expressions: [
+                { modifier: "min", feature: "height", value: "150px" },
+                { modifier: "max", feature: "height", value: "200px" }
+              ]
+            }
+          ]
+        },
         a: 0,
         "@media screen and (min-height: 50px) and (max-height: 150px)": {
           a: 1
@@ -156,6 +351,28 @@ describe("media queries", () => {
   it("should support all type", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media all and (min-height: 150px) and (max-height: 200px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "150px" },
+                { modifier: "max", feature: "height", value: "200px" }
+              ]
+            }
+          ],
+          "@media all and (min-height: 50px) and (max-height: 150px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "50px" },
+                { modifier: "max", feature: "height", value: "150px" }
+              ]
+            }
+          ]
+        },
         a: 0,
         "@media all and (min-height: 150px) and (max-height: 200px)": {
           a: 1
@@ -170,6 +387,40 @@ describe("media queries", () => {
   it("should support OR queries", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media all and (min-height: 150px), (max-height: 200px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "150px" }
+              ]
+            },
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "max", feature: "height", value: "200px" }
+              ]
+            }
+          ],
+          "@media all and (min-height: 200px), (max-height: 150px)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "min", feature: "height", value: "200px" }
+              ]
+            },
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                { modifier: "max", feature: "height", value: "150px" }
+              ]
+            }
+          ]
+        },
         a: 0,
         "@media all and (min-height: 150px), (max-height: 200px)": {
           a: 1
@@ -181,6 +432,32 @@ describe("media queries", () => {
     ).toEqual({ a: 2 });
     expect(
       process({
+        __mediaQueries: {
+          "@media (orientation: portrait), (orientation: landscape)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                {
+                  modifier: undefined,
+                  feature: "orientation",
+                  value: "portrait"
+                }
+              ]
+            },
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                {
+                  modifier: undefined,
+                  feature: "orientation",
+                  value: "landscape"
+                }
+              ]
+            }
+          ]
+        },
         a: 1,
         "@media (orientation: portrait), (orientation: landscape)": {
           a: 2
@@ -192,6 +469,34 @@ describe("media queries", () => {
   it("should process orientation", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media (orientation: landscape)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                {
+                  modifier: undefined,
+                  feature: "orientation",
+                  value: "landscape"
+                }
+              ]
+            }
+          ],
+          "@media (orientation: portrait)": [
+            {
+              inverse: false,
+              type: "all",
+              expressions: [
+                {
+                  modifier: undefined,
+                  feature: "orientation",
+                  value: "portrait"
+                }
+              ]
+            }
+          ]
+        },
         "@media (orientation: landscape)": {
           a: 1
         },
@@ -205,6 +510,22 @@ describe("media queries", () => {
   it("should process type", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media ios": [
+            {
+              inverse: false,
+              type: "ios",
+              expressions: []
+            }
+          ],
+          "@media android": [
+            {
+              inverse: false,
+              type: "android",
+              expressions: []
+            }
+          ]
+        },
         "@media ios": {
           a: 1
         },
@@ -215,6 +536,22 @@ describe("media queries", () => {
     ).toEqual({ a: 1 });
     expect(
       process({
+        __mediaQueries: {
+          "@media android": [
+            {
+              inverse: false,
+              type: "android",
+              expressions: []
+            }
+          ],
+          "@media ios": [
+            {
+              inverse: false,
+              type: "ios",
+              expressions: []
+            }
+          ]
+        },
         "@media android": {
           a: 1
         },
@@ -228,6 +565,17 @@ describe("media queries", () => {
   it("should ignore non-matching media queries", () => {
     expect(
       process({
+        __mediaQueries: {
+          "@media print and (min-width: 50px)": [
+            {
+              inverse: false,
+              type: "print",
+              expressions: [
+                { modifier: "min", feature: "width", value: "50px" }
+              ]
+            }
+          ]
+        },
         a: 0,
         "@media print and (min-width: 50px)": {
           a: 1

--- a/src/mediaquery.js
+++ b/src/mediaquery.js
@@ -6,12 +6,22 @@ See the accompanying LICENSE file for terms.
 
 "use strict";
 
-exports.match = matchQuery;
+exports.match = match;
 
 // -----------------------------------------------------------------------------
 
 var RE_LENGTH_UNIT = /(em|rem|px|cm|mm|in|pt|pc)?\s*$/,
   RE_RESOLUTION_UNIT = /(dpi|dpcm|dppx)?\s*$/;
+
+function match(parsed, values) {
+  if (!parsed) {
+    return false;
+  }
+  if (parsed.length === 1) {
+    return matchQuery(parsed[0], values);
+  }
+  return parsed.some(mq => matchQuery(mq, values));
+}
 
 function matchQuery(query, values) {
   var inverse = query.inverse;

--- a/src/perf-tests/parsed.js
+++ b/src/perf-tests/parsed.js
@@ -1,4 +1,4 @@
-import mediaQuery from "./mq.js";
+import mediaQuery from "../mediaquery.js";
 import merge from "deepmerge";
 import memoize from "micro-memoize";
 
@@ -10,6 +10,15 @@ function isObject(obj) {
 
 function isMediaQuery(str) {
   return typeof str === "string" && str.indexOf(PREFIX) === 0;
+}
+
+function omit(obj, omitKey) {
+  return Object.keys(obj).reduce((result, key) => {
+    if (key !== omitKey) {
+      result[key] = obj[key];
+    }
+    return result;
+  }, {});
 }
 
 function filterMq(obj) {
@@ -27,6 +36,7 @@ function filterNonMq(obj) {
 
 const mFilterMq = memoize(filterMq);
 const mFilterNonMq = memoize(filterNonMq);
+const mOmit = memoize(omit);
 
 export function process(obj, matchObject, Platform) {
   const mqKeys = mFilterMq(obj);
@@ -39,6 +49,8 @@ export function process(obj, matchObject, Platform) {
   mqKeys.forEach(key => {
     if (/^@media\s+(ios|android)/i.test(key)) {
       matchObject.type = Platform.OS;
+    } else {
+      matchObject.type = "screen";
     }
 
     const isMatch = mediaQuery.match(obj.__mediaQueries[key], matchObject);
@@ -47,5 +59,5 @@ export function process(obj, matchObject, Platform) {
     }
   });
 
-  return res;
+  return mOmit(res, "__mediaQueries");
 }


### PR DESCRIPTION
Instead parsing media queries at runtime, require media queries to already be parsed and exist under `__mediaQueries` key.